### PR TITLE
[Change] Use user array for appending user data when storing, updating templates

### DIFF
--- a/Tests/Integration/ClientTest.php
+++ b/Tests/Integration/ClientTest.php
@@ -218,17 +218,27 @@ class ClientTest extends TestCase
      */
     public function it_can_create_an_agenda_template_with_the_correct_data()
     {
+        $userData = [
+            'name' => 'name',
+            'email' => 'name@email.com',
+            'avatar' => 'https://avatar.com',
+            'soapbox-user-id' => 1,
+        ];
+
         $handler = $this->fakeRequests();
         $handler->post('agenda-templates')
             ->inspectRequest(function ($request) {
                 $content = json_decode((string) $request->getBody(), true);
-                $this->assertEquals($content['soapbox-user-id'], 1);
+                $this->assertEquals($content['author-name'], $userData['name']);
+                $this->assertEquals($content['author-email'], $userData['email']);
+                $this->assertEquals($content['author-avatar'], $userData['avatar']);
+                $this->assertEquals($content['soapbox-user-id'], $userData['soapbox-user-id']);
                 $this->assertEquals($content['soapbox-id'], 10);
                 $this->assertEquals($content['test'], 'test data');
             })->respondWith(200);
 
         $client = resolve(Client::class);
-        $response = $client->createAgendaTemplate(1, 10, ['test' => 'test data']);
+        $response = $client->createAgendaTemplate($userData, 10, ['test' => 'test data']);
 
         $this->assertEquals($response->getStatusCode(), 200);
     }
@@ -252,16 +262,26 @@ class ClientTest extends TestCase
      */
     public function it_can_update_an_agenda_template_with_the_correct_data()
     {
+        $userData = [
+            'name' => 'name',
+            'email' => 'name@email.com',
+            'avatar' => 'https://avatar.com',
+            'soapbox-user-id' => 1,
+        ];
+
         $handler = $this->fakeRequests();
         $handler->put('agenda-templates/2')
             ->inspectRequest(function ($request) {
                 $content = json_decode((string) $request->getBody(), true);
-                $this->assertEquals($content['soapbox-user-id'], 1);
+                $this->assertEquals($content['author-name'], $userData['name']);
+                $this->assertEquals($content['author-email'], $userData['email']);
+                $this->assertEquals($content['author-avatar'], $userData['avatar']);
+                $this->assertEquals($content['soapbox-user-id'], $userData['soapbox-user-id']);
                 $this->assertEquals($content['test'], 'test data');
             })->respondWith(200);
 
         $client = resolve(Client::class);
-        $response = $client->updateAgendaTemplate(1, 2, ['test' => 'test data']);
+        $response = $client->updateAgendaTemplate($userData, 2, ['test' => 'test data']);
 
         $this->assertEquals($response->getStatusCode(), 200);
     }

--- a/src/Client.php
+++ b/src/Client.php
@@ -2,6 +2,7 @@
 
 namespace SoapBox\AgendaTemplateClient;
 
+use App\Users\User;
 use Illuminate\Http\Response;
 use Illuminate\Config\Repository;
 use JSHayes\FakeRequests\ClientFactory;
@@ -156,15 +157,18 @@ class Client
      * @throws \GuzzleHttp\Exception\RequestException
      * Thrown if a response was not returned from the agenda template service
      *
-     * @param int $userId
+     * @param array $userData
      * @param int $soapboxId
-     * @param int $data
+     * @param array $data
      *
      * @return \Illuminate\Http\Response
      */
-    public function createAgendaTemplate(int $userId, int $soapboxId, array $data): Response
+    public function createAgendaTemplate(array $userData, int $soapboxId, array $data): Response
     {
-        $data['soapbox-user-id'] = $userId;
+        $data['author-name'] = $userData['name'];
+        $data['author-email'] = $userData['email'];
+        $data['author-avatar'] = $userData['avatar'];
+        $data['soapbox-user-id'] = $userData['soapbox-user-id'];
         $data['soapbox-id'] = $soapboxId;
 
         return $this->makeRequestAndReturnResponse("post", "agenda-templates", $data);
@@ -176,15 +180,18 @@ class Client
      * @throws \GuzzleHttp\Exception\RequestException
      * Thrown if a response was not returned from the agenda template service
      *
-     * @param int $userId
+     * @param array $userData
      * @param int $agendaTemplateId
-     * @param int $data
+     * @param array $data
      *
      * @return \Illuminate\Http\Response
      */
-    public function updateAgendaTemplate(int $userId, int $agendaTemplateId, array $data): Response
+    public function updateAgendaTemplate(array $userData, int $agendaTemplateId, array $data): Response
     {
-        $data['soapbox-user-id'] = $userId;
+        $data['author-name'] = $userData['name'];
+        $data['author-email'] = $userData['email'];
+        $data['author-avatar'] = $userData['avatar'];
+        $data['soapbox-user-id'] = $userData['soapbox-user-id'];
 
         return $this->makeRequestAndReturnResponse("put", "agenda-templates/{$agendaTemplateId}", $data);
     }


### PR DESCRIPTION
#### [LINEAR] What Linear tickets does this PR address?
https://linear.app/hypercontext/issue/HYP-16596/[api]-update-suggestions-provider-service-to-receive-and-store-author

#### [SUMMARY] What's this PR do?
- Changes `createAgendaTemplate` and `updateAgendaTemplate` functions to expect user array
- Appends data from user array to request data

#### [TEST CASES] How should this be tested?
- tests pass
- test the api branch https://github.com/Soapbox/GoodTalk-API/pull/2510
  - make same changes in this PR to `vendor/soapbox/agenda-template-client/src/Client.php`

I tested it myself, and it works!